### PR TITLE
CC-271 Remove the footer from the neuroglancer cryoet data portal

### DIFF
--- a/frontend/packages/data-portal/app/components/Layout/Footer.tsx
+++ b/frontend/packages/data-portal/app/components/Layout/Footer.tsx
@@ -4,6 +4,7 @@ import { CZIIcon, ImageInstituteIcon } from 'app/components/icons'
 import { Link } from 'app/components/Link'
 import { i18n } from 'app/i18n'
 import { cns } from 'app/utils/cns'
+import { useLocation } from '@remix-run/react'
 
 import { CryoETHomeLink } from './CryoETHomeLink'
 
@@ -42,6 +43,8 @@ const LEGAL_LINKS = [
 ]
 
 export function Footer() {
+  const { pathname } = useLocation()
+
   const legalLinks = (
     <div className="flex items-center gap-sds-s">
       {LEGAL_LINKS.map(({ label, href }, idx) => (
@@ -74,6 +77,12 @@ export function Footer() {
       </Link>
     </div>
   )
+
+  const isItNeuroglancerPage = pathname.includes("/view/runs/");
+
+  if (isItNeuroglancerPage) {
+    return null;
+  }
 
   return (
     <footer className="bg-sds-color-primitive-common-black min-h-[213px] pt-[41px] pb-sds-xxl px-sds-xl screen-716:px-sds-xxl flex flex-col flex-shrink-0">


### PR DESCRIPTION
Issue [#CC-271 ](https://metacell.atlassian.net/browse/CC-271)
Problem: Remove the footer from the neuroglancer cryoet data portal
Solution: 
1. Remove footer by checking if the location path is on neuroglancer page, if yes return `null` instead of footer
