### PR TITLE
CC-295 On clicking the layout button again, it seems to select the iframe

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.css
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.css
@@ -8,12 +8,13 @@
 .iframe-container {
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
+  user-select: none;
+  user-select: none;
+  user-select: none;
+  user-select: none;
   user-select: none;
 }
+
 .iframe-container:focus {
   outline: none !important;
 }


### PR DESCRIPTION
Issue [#CC-295](https://metacell.atlassian.net/browse/CC-295)
Problem: On clicking the layout button again, it seems to select the iframe
Solution: 
1. The blue overlay appears if we click on dropdown quickly, thus applied some css to iframe container to make it transparent and removes the effect (solution for different browsers)

Result: 

https://github.com/user-attachments/assets/c09089db-7f8f-4bc3-9ead-debe2e7e4237

