### PR TITLE
CC-309 Add keyboard shortcut indicators to the actions dropdown

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -143,6 +143,7 @@ function ViewerPage({ run } : { run: any }) {
     });
   }
 
+  const helperText = "text-xs text-[#767676] font-normal";
   const activeBreadcrumbText = (
     <p>
       {run.name} <span className='text-sds-color-primitive-common-white opacity-60'>(#RN-{run.id})</span>
@@ -175,7 +176,7 @@ function ViewerPage({ run } : { run: any }) {
                     onSelect={() => toggleLayer(annotation.name)}
                   >
                     <span>{annotation?.name}</span>
-                    <span className="text-xs text-[#767676] font-normal">#CZCDP-12795</span>
+                    <span className={helperText}>#CZCDP-12795</span>
                   </CustomDropdownOption>
                 ))}
               </CustomDropdownSection>
@@ -195,13 +196,33 @@ function ViewerPage({ run } : { run: any }) {
             </CustomDropdown>
             <CustomDropdown title="Actions" variant="outlined">
               <CustomDropdownSection title="Appearance">
-                <CustomDropdownOption selected={hasBoundingBox()} onSelect={toggleBoundingBox}>Bounding box</CustomDropdownOption>
-                <CustomDropdownOption selected={axisLineEnabled()} onSelect={toggleAxisLine}>Axis lines</CustomDropdownOption>
-                <CustomDropdownOption selected={showScaleBarEnabled()} onSelect={toggleShowScaleBar}>Scale bar</CustomDropdownOption>
+                <CustomDropdownOption selected={hasBoundingBox()} onSelect={toggleBoundingBox}>
+                  <div className='flex justify-between items-center'>
+                    <p>Bounding box</p>
+                    <p className={helperText}>v</p>
+                  </div>
+                </CustomDropdownOption>
+                <CustomDropdownOption selected={axisLineEnabled()} onSelect={toggleAxisLine}>
+                  <div className='flex justify-between items-center'>
+                    <p>Axis lines</p>
+                    <p className={helperText}>a</p>
+                  </div>
+                </CustomDropdownOption>
+                <CustomDropdownOption selected={showScaleBarEnabled()} onSelect={toggleShowScaleBar}>
+                  <div className='flex justify-between items-center'>
+                    <p>Scale bar</p>
+                    <p className={helperText}>b</p>
+                  </div>
+                </CustomDropdownOption>
                 <CustomDropdownOption selected={isBackgroundWhite()} onSelect={() => changeBackgroundColor(BACKGROUND_COLOR)}>Change background to white</CustomDropdownOption>
               </CustomDropdownSection>
               <CustomDropdownSection title="Move">
-                <CustomDropdownOption selected={false} onSelect={snap}>Snap to the nearest axis</CustomDropdownOption>
+                <CustomDropdownOption selected={false} onSelect={snap}>
+                  <div className='flex justify-between items-center'>
+                    <p>Snap to the nearest axis</p>
+                    <p className={helperText}>z</p>
+                  </div>
+                </CustomDropdownOption>
               </CustomDropdownSection>
             </CustomDropdown>
             <Button sdsType="primary" sdsStyle="rounded" disabled={shareClicked} onClick={handleShareClick}>Share</Button>

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -214,7 +214,7 @@ function ViewerPage({ run } : { run: any }) {
               <CustomDropdownSection title="Move">
                 <CustomDropdownOption selected={false} onSelect={snap}>
                   <div className='flex justify-between items-center'>
-                    <p>Snap to the nearest axis</p>
+                    <p>Snap to nearest axis</p>
                     <p className={helperText}>z</p>
                   </div>
                 </CustomDropdownOption>

--- a/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
@@ -37,8 +37,8 @@ export function CustomDropdownOption({
   onClick?: () => void
 }) {
   return (
-    <MenuItem {...props} onClick={onSelect}>
-      <div className="flex items-center justify-center flex-auto gap-3">
+    <MenuItem {...props} onClick={onSelect} sx={{ "& .primary-text": { width: "100%" } }}>
+      <div className="flex items-center justify-center flex-auto gap-3 w-full">
         <div className="inline-flex w-4 h-4">
           {selected ? (
             <Icon
@@ -49,7 +49,7 @@ export function CustomDropdownOption({
             />
           ) : null}
         </div>
-        <div className={cns(selected && 'font-semibold', 'flex flex-col')}>
+        <div className={cns(selected && 'font-semibold', 'flex flex-col w-full')}>
           {children}
         </div>
       </div>


### PR DESCRIPTION
Issue [#CC-309](https://metacell.atlassian.net/browse/CC-309) 
Problem: Add keyboard shortcut indicators to the actions dropdown
Solution: 
1. Add shortcut to the end of actions menu item option

Result: 
![image](https://github.com/user-attachments/assets/f6a31ae5-d060-4b4a-95a2-2080eff6568d)

