### PR TITLE
CC-310 Improve sizing of dropdown menus

### DIFF
--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -9,12 +9,14 @@ export function MenuDropdown({
   title,
   variant = 'standard',
   buttonElement,
+  paperClassName
 }: {
   children: ReactNode
   variant?: 'standard' | 'outlined' | 'filled'
   className?: string
   title: ReactNode
   buttonElement?: ReactNode
+  paperClassName?: string
 }) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -92,6 +94,11 @@ export function MenuDropdown({
         open={!!anchorEl}
         onClose={() => setAnchorEl(null)}
         className="mt-2"
+        slotProps={{
+          paper: {
+            className: paperClassName,
+          },
+        }}
       >
         {children}
       </Menu>

--- a/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
@@ -76,6 +76,7 @@ export function CustomDropdown({
       title={title}
       variant={variant}
       buttonElement={buttonElement}
+      paperClassName="!min-w-[250px]"
     >
       {children}
     </MenuDropdown>


### PR DESCRIPTION
Issue [#CC-310](https://metacell.atlassian.net/browse/CC-310)
Problem: Improve sizing of dropdown menus
Solution: 
1. Use slotProps to set min-width and pass it as a prop

Result: 

https://github.com/user-attachments/assets/f9a44d3e-a9e1-4aec-b68d-4a3d760d470f

