### PR TITLE
fix: simplify logic around snackbar open/close

### DIFF
--- a/frontend/packages/data-portal/app/components/common/Snackbar.tsx
+++ b/frontend/packages/data-portal/app/components/common/Snackbar.tsx
@@ -22,32 +22,22 @@ function Snackbar({
   handleClose,
   autoHideDuration = 8000,
 }: SnackbarProps) {
-  const [localOpen, setLocalOpen] = useState(open)
-
   useEffect(() => {
-    setLocalOpen(open)
-
     if (open) {
       const timer = setTimeout(() => {
-        setLocalOpen(false)
         handleClose()
       }, autoHideDuration)
 
       return () => clearTimeout(timer)
     }
-  }, [open, handleClose, autoHideDuration])
-
-  if (!localOpen) {
-    return null
-  }
+  }, [open])
 
   return (
-    <Notification
+    open && <Notification
       intent={intent}
       slideDirection="right"
       autoDismiss={autoHideDuration}
       onClose={() => {
-        setLocalOpen(false)
         handleClose()
       }}
       className={cns('absolute bottom-0 left-3 z-10 !min-w-[392px]', className)}


### PR DESCRIPTION
I think there is a bit of a simplification we can make here that should fix a bug, and improve performance.

1. I think the snackbar doesn't need it's own state. It is getting the state passed to it from the parent, and `handleClose` can be directly used to update the parent state.
2. I think the `useEffect` hook does not need so many dependencies. I'd expect the only real thing to change to be the `open` bool, not the other two -- this might cause extra calls to the hook having these.

The bug before these I think was from 2. It would prevent the snackbar from showing again after one had showed -- probably due to `useEffect` changing some local snackbar state