### PR TITLE
feat: toggle top bar stored in superstate

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -177,13 +177,26 @@ const togglePanels = () => {
 }
 
 const toggleTopBar = () => {
+  const isVisible = isTopBarVisible()
+  updateState((state) => {
+    state.showLayerTopBar = !isVisible
+    return state
+  })
   const viewer = currentNeuroglancer()
-  viewer.uiConfiguration.showLayerPanel.value = !isTopBarVisible()
+  viewer.uiConfiguration.showLayerPanel.value = !isVisible
 }
 
 const isTopBarVisible = () => {
+  const state = currentState()
+  return boolValue(state.showLayerTopBar, /* defaultValue = */ false)
+}
+
+const setTopBarVisibleFromSuperState = () => {
   const viewer = currentNeuroglancer()
-  return viewer?.uiConfiguration?.showLayerPanel.value ?? false
+  const isVisible = viewer.uiConfiguration.showLayerPanel.value
+  const shouldBeVisible = isTopBarVisible()
+  if (isVisible === shouldBeVisible) return
+  viewer.uiConfiguration.showLayerPanel.value = shouldBeVisible
 }
 
 const buildDepositsConfig = (annotations: any) => {
@@ -275,6 +288,7 @@ function ViewerPage({ run }: { run: any }) {
 
   const handleOnStateChange = (state: ResolvedSuperState) => {
     scheduleRefresh()
+    setTopBarVisibleFromSuperState()
     if (!state.savedPanelsStatus) {
       return
     }
@@ -406,7 +420,9 @@ function ViewerPage({ run }: { run: any }) {
             <CustomDropdown title="Layout" variant="outlined">
               <CustomDropdownSection title="Layout">
                 <CustomDropdownOption
-                  selected={isCurrentLayout('4panel') || isCurrentLayout('4panel-alt')}
+                  selected={
+                    isCurrentLayout('4panel') || isCurrentLayout('4panel-alt')
+                  }
                   onSelect={() => setCurrentLayout('4panel')}
                 >
                   4 panel
@@ -445,10 +461,7 @@ function ViewerPage({ run }: { run: any }) {
                 </CustomDropdownOption>
                 <CustomDropdownOption
                   selected={isTopBarVisible()}
-                  onSelect={() => {
-                    toggleTopBar()
-                    scheduleRefresh()
-                  }}
+                  onSelect={toggleTopBar}
                 >
                   Show top layer bar
                 </CustomDropdownOption>

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -193,10 +193,7 @@ const isTopBarVisible = () => {
 
 const setTopBarVisibleFromSuperState = () => {
   const viewer = currentNeuroglancer()
-  const isVisible = viewer.uiConfiguration.showLayerPanel.value
-  const shouldBeVisible = isTopBarVisible()
-  if (isVisible === shouldBeVisible) return
-  viewer.uiConfiguration.showLayerPanel.value = shouldBeVisible
+  viewer.uiConfiguration.showLayerPanel.value = isTopBarVisible()
 }
 
 const buildDepositsConfig = (annotations: any) => {


### PR DESCRIPTION
Allows the top bar show/close to be stored in the super state and used to restore the top bar state

Very open to thoughts on how to best achieve this. Right now it checks every time the state is updated because sure if we should instead say -- "hey, when neuroglancer is ready in the iframe, do this check one time on the layer top bar"

Also I wasn't too sure if this superstate could actually be changed from elsewhere, not just in the layer top bar toggle. Probably it would only be from that I think