### PR TITLE
feat: show hide layer controls panel for tour

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -302,7 +302,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
     else if (newIndex === 4)
       updateTourStepFromState(false /* layerControlVisibility = */)
     else {
-      // On step 3 and 5 we may not needc to update the state,
+      // On step 3 and 5 we may not need to update the state,
       const { neuroglancer } = currentState()
       const isPanelVisible = boolValue(
         neuroglancer.selectedLayer?.visible,

--- a/frontend/packages/data-portal/app/components/Run/steps.tsx
+++ b/frontend/packages/data-portal/app/components/Run/steps.tsx
@@ -90,6 +90,7 @@ export const getTutorialSteps: () => Step[] = () => [
     ),
     title: 'Main viewport',
     placement: 'left-start',
+    disableBeacon: true,
     content: (
       <StepContent variant="compact">
         <div className="text-[#767676]">
@@ -114,6 +115,7 @@ export const getTutorialSteps: () => Step[] = () => [
     ),
     title: 'Essential controls',
     placement: 'left',
+    disableBeacon: true,
     content: (
       <StepContent variant="simple">
         <div className="mt-4 mb-4">
@@ -138,6 +140,7 @@ export const getTutorialSteps: () => Step[] = () => [
     ),
     title: 'Keyboard shortcuts',
     placement: 'left',
+    disableBeacon: true,
     content: (
       <StepContent variant="simple">
         <div className="mt-4 mb-4">
@@ -164,6 +167,7 @@ export const getTutorialSteps: () => Step[] = () => [
     ),
     title: 'Layer management',
     placement: 'right-start',
+    disableBeacon: true,
     content: (
       <StepContent variant="simple">
         <div className="mt-4 mb-4">
@@ -190,6 +194,7 @@ export const getTutorialSteps: () => Step[] = () => [
     target: getIframeElement('.neuroglancer-layer-side-panel-tab-view'),
     title: 'Layer controls',
     placement: 'right-start',
+    disableBeacon: true,
     content: (
       <StepContent variant="minimal">
         <p className="text-[#767676]">
@@ -206,6 +211,7 @@ export const getTutorialSteps: () => Step[] = () => [
     target: getIframeElement('.neuroglancer-viewer-top-row'),
     title: 'Controls top panel',
     placement: 'bottom-end',
+    disableBeacon: true,
     content: (
       <StepContent variant="minimal">
         <p className="text-[#767676] flex flex-col gap-4">
@@ -222,6 +228,7 @@ export const getTutorialSteps: () => Step[] = () => [
     target: '.neuroglancerIframe',
     placement: 'center',
     title: 'Congratulations!',
+    disableBeacon: true,
     content: (
       <StepContent variant="default">
         <p className="flex flex-col gap-3">


### PR DESCRIPTION
step 4 of our tour used to overflow. Proposed fix here is to just hide the controls panel and it would fix it. There will be a small delay before step 4 and step 5 show, but this might be fine

Not sure of a different way to handle the sync between the state and the tour, hopefully what I've done makes sense but very open to suggestions

See what you think!

https://github.com/user-attachments/assets/53b37b9d-40bc-4143-8008-20cdf22d94eb

