### PR TITLE
CC-364 Rollback overall change to be in dark theme. Instead update only the header bar styling

### DIFF
--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -52,7 +52,7 @@ export const MenuDropdown = forwardRef<
       standard: anchorEl
         ? '!fill-sds-color-primitive-common-white'
         : '!fill-sds-color-primitive-gray-400 group-hover:!fill-sds-color-primitive-common-white',
-      outlined: '!fill-[#A2C9FF]',
+      outlined: '!text-[#A2C9FF]',
       filled: '!fill-sds-color-primitive-common-white',
     }
 

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -419,7 +419,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
   )
 
   return (
-    <div className="flex flex-col overflow-hidden h-full relative">
+    <div className="flex flex-col overflow-hidden h-full relative bg-dark-sds-color-primitive-gray-50">
       <nav
         className={cns(
           'bg-sds-color-primitive-common-black text-sds-color-primitive-common-white',

--- a/frontend/packages/data-portal/app/routes/view.runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/view.runs.$id.tsx
@@ -3,19 +3,12 @@
 import { type LoaderFunctionArgs } from '@remix-run/server-runtime'
 import { lazy, Suspense } from 'react'
 import { typedjson } from 'remix-typedjson'
-import { ThemeProvider as EmotionThemeProvider } from '@emotion/react'
-import { StyledEngineProvider, ThemeProvider } from '@mui/material/styles'
 import { makeThemeOptions, SDSDarkAppTheme } from '@czi-sds/components'
-import CssBaseline from '@mui/material/CssBaseline'
-import { createTheme } from '@mui/material/styles'
 
 import { apolloClientV2 } from 'app/apollo.server'
 import { QueryParams } from 'app/constants/query'
 import { getRunByIdV2 } from 'app/graphql/getRunByIdV2.server'
 import { useRunById } from 'app/hooks/useRunById'
-
-const appTheme = makeThemeOptions(SDSDarkAppTheme, 'dark')
-const theme = createTheme(appTheme)
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const id = params.id ? +params.id : NaN
@@ -59,15 +52,8 @@ export default function RunByIdViewerPage() {
   const { run, tomograms } = useRunById()
   const tomogram = tomograms.find((t) => t.neuroglancerConfig)
   return (
-    <StyledEngineProvider>
-      <ThemeProvider theme={theme}>
-        <EmotionThemeProvider theme={theme}>
-          <CssBaseline />
-          <Suspense fallback={<div>Loading...</div>}>
-            <ViewerPage run={run} tomogram={tomogram} />
-          </Suspense>
-        </EmotionThemeProvider>
-      </ThemeProvider>
-    </StyledEngineProvider>
+    <Suspense fallback={<div>Loading...</div>}>
+      <ViewerPage run={run} tomogram={tomogram} />
+    </Suspense>
   )
 }


### PR DESCRIPTION
Issue [#CC-364](https://metacell.atlassian.net/browse/CC-364) 
Problems: Rollback overall change to be in dark theme. Instead update only the header bar styling
Solution: 
1. Delete theme configuration in view.run file
2. Change bg color of header to be dark 
3. Update some styling accordingly

Result: 
![image](https://github.com/user-attachments/assets/72d69aa6-a942-4acc-9019-5c538636169c)

