### PR TITLE
CC-363 Give the walktrhough tour start element a hover effect to match the others in the dropdown

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -601,7 +601,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
                 </MenuItemLink>
                 <button
                   type="button"
-                  className="py-1.5 px-2"
+                  className="py-1.5 px-2 w-full text-left hover:bg-light-sds-color-primitive-gray-300 hover:bg-opacity-30"
                   onClick={handleTourStartInNewTab}
                 >
                   {t('neuroglancerWalkthrough')}


### PR DESCRIPTION
Issue [#CC-363](https://metacell.atlassian.net/browse/CC-363) 
Problem: Give the walktrhough tour start element a hover effect to match the others in the dropdown
Solution: 
1. Update styling of tour button

Result: 

https://github.com/user-attachments/assets/bc009871-bbb7-4b52-b4f8-e1a612510498

