### PR TITLE
CC-361 Styling for the deposition name in the frontend wrapper

### DIFF
--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -17,7 +17,6 @@ import { ACTIONS } from 'react-joyride'
 import { Breadcrumbs } from 'app/components/Breadcrumbs'
 import { InfoIcon } from 'app/components/icons'
 import { MenuItemLink } from 'app/components/MenuItemLink'
-import { Tooltip } from '../Tooltip'
 import { useI18n } from 'app/hooks/useI18n'
 import { cns } from 'app/utils/cns'
 
@@ -463,15 +462,9 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
                             toggleDepositions(layersOfInterest)
                           }}
                         >
-                          <Tooltip
-                            tooltip={
-                              depositions?.[0].annotation.deposition.title
-                            }
-                          >
-                            <span className="line-clamp-2">
-                              {depositions?.[0].annotation.deposition.title}
-                            </span>
-                          </Tooltip>
+                          <span className="line-clamp-3">
+                            {depositions?.[0].annotation.deposition.title}
+                          </span>
                           <span className="text-xs text-[#767676] font-normal">
                             CZCDP-{depositionId}
                           </span>

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -17,6 +17,7 @@ import { ACTIONS } from 'react-joyride'
 import { Breadcrumbs } from 'app/components/Breadcrumbs'
 import { InfoIcon } from 'app/components/icons'
 import { MenuItemLink } from 'app/components/MenuItemLink'
+import { Tooltip } from '../Tooltip'
 import { useI18n } from 'app/hooks/useI18n'
 import { cns } from 'app/utils/cns'
 
@@ -458,9 +459,11 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
                           toggleDepositions(layersOfInterest)
                         }}
                       >
-                        <span>
-                          {depositions?.[0].annotation.deposition.title}
-                        </span>
+                        <Tooltip tooltip={depositions?.[0].annotation.deposition.title}>
+                          <span className="line-clamp-2">
+                            {depositions?.[0].annotation.deposition.title}
+                          </span>
+                        </Tooltip>
                         <span className="text-xs text-[#767676] font-normal">
                           #CZCDP-{depositionId}
                         </span>

--- a/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
@@ -103,7 +103,7 @@ export function CustomDropdown({
       title={title}
       variant={variant}
       buttonElement={buttonElement}
-      paperClassName="!min-w-[250px] !max-w-[320px]"
+      paperClassName="!min-w-[250px] !max-w-[380px]"
     >
       {wrapChildrenWithCloseHandler(children)}
     </MenuDropdown>

--- a/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
@@ -103,7 +103,7 @@ export function CustomDropdown({
       title={title}
       variant={variant}
       buttonElement={buttonElement}
-      paperClassName="!min-w-[250px]"
+      paperClassName="!min-w-[250px] !max-w-[320px]"
     >
       {wrapChildrenWithCloseHandler(children)}
     </MenuDropdown>


### PR DESCRIPTION
Issue [#CC-361](https://metacell.atlassian.net/browse/CC-361)
Problem: Styling for the deposition name in the frontend wrapper
Solution: 
1. Render a tooltip on deposition name
2. Break text into 2 lines with line-clamp property
3. Make dropdown to have max width of 320px

Result: 

https://github.com/user-attachments/assets/b555b1b2-58dc-4f96-8e23-fda24858d4dd

