### PR TITLE
feat: override palette theme for portal

### DIFF
--- a/frontend/packages/neuroglancer/index.html
+++ b/frontend/packages/neuroglancer/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cryoet-Neuroglancer</title>
+    <link rel="stylesheet" href="/src/cryoet-portal-theme.css" />
     <script type="module">
       import 'neuroglancer'
       import { setupDefaultViewer } from 'neuroglancer/unstable/ui/default_viewer_setup.js'

--- a/frontend/packages/neuroglancer/src/cyroet-portal-theme.css
+++ b/frontend/packages/neuroglancer/src/cyroet-portal-theme.css
@@ -1,0 +1,20 @@
+.neuroglancer-tool-palette-query {
+    display: none !important;
+}
+
+.neuroglancer-tool-palette-items {
+    flex-direction: row !important;
+    align-items: flex-start !important;
+    overflow-x: auto !important;
+    height: 100% !important;
+}
+
+.neuroglancer-tool-palette-tool-container {
+    width: 100% !important;
+    align-items: flex-start !important;
+}
+
+.neuroglancer-side-panel-drop-zone {
+    width: 0px !important;
+    display: none !important;
+}


### PR DESCRIPTION
Forces all palettes to be horizontal in the styling. Noticed from this that the layout probably wants to have an option to show/hide this too. Styling override not needed if at some point horizontal palettes are natively available in ng main