### PR TITLE
CC-360 Update styling for going back to run and back to dataset

### DIFF
--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -175,7 +175,7 @@ export function Breadcrumbs({
     return (
       <div className="flex flex-row gap-sds-s text-dark-sds-color-primitive-gray-500 fill-[#999] font-normal text-sds-body-s-400-wide leading-sds-body-s items-center whitespace-nowrap content-start">
         <Tooltip
-          tooltip={`Go to ${data.title || t('dataset')}`}
+          tooltip={`Go to Dataset ${data.title || t('dataset')}`}
           className="overflow-hidden overflow-ellipsis"
         >
           <Breadcrumb

--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -175,7 +175,7 @@ export function Breadcrumbs({
     return (
       <div className="flex flex-row gap-sds-s text-dark-sds-color-primitive-gray-500 fill-[#999] font-normal text-sds-body-s-400-wide leading-sds-body-s items-center whitespace-nowrap content-start">
         <Tooltip
-          tooltip={data.title || t('dataset')}
+          tooltip={`Go to ${data.title || t('dataset')}`}
           className="overflow-hidden overflow-ellipsis"
         >
           <Breadcrumb

--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -34,8 +34,8 @@ function Breadcrumb({
     <Link
       to={link}
       className={cns(
-        className,
         'hover:text-light-sds-color-primitive-blue-500',
+        className,
       )}
       onClick={() => {
         if (type) {
@@ -181,7 +181,7 @@ export function Breadcrumbs({
           <Breadcrumb
             text={data.title || t('dataset')}
             link={singleDatasetLink}
-            className="overflow-ellipsis overflow-hidden flex-initial"
+            className="overflow-ellipsis overflow-hidden flex-initial hover:text-light-sds-color-primitive-gray-50"
             type={BreadcrumbType.SingleDataset}
             datasetId={data.id}
           />

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -31,8 +31,8 @@ import {
   NEUROGLANCER_DOC_LINK,
   REPORT_LINKS,
 } from '../Layout/constants'
-import { Tooltip } from '../Tooltip'
 import { CryoETHomeLink } from '../Layout/CryoETHomeLink'
+import { Tooltip } from '../Tooltip'
 import { NeuroglancerBanner } from './NeuroglancerBanner'
 import { getTutorialSteps } from './steps'
 import Tour from './Tour'
@@ -412,8 +412,14 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
 
   const helperText = 'text-xs text-[#767676] font-normal'
   const activeBreadcrumbText = (
-    <Tooltip tooltip={`Go to Run ${run.name || t('runName')}`} className="flex items-center overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
-      <a href={`${window.origin}/runs/${run.id}`} className="overflow-hidden overflow-ellipsis">
+    <Tooltip
+      tooltip={`Go to Run ${run.name || t('runName')}`}
+      className="flex items-center overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]"
+    >
+      <a
+        href={`${window.origin}/runs/${run.id}`}
+        className="overflow-hidden overflow-ellipsis"
+      >
         {run.name}{' '}
       </a>
       <span className="text-sds-color-primitive-common-white opacity-60 ml-1">

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -412,7 +412,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
 
   const helperText = 'text-xs text-[#767676] font-normal'
   const activeBreadcrumbText = (
-    <Tooltip tooltip={`Go to ${run.name || t('runName')}`} className="flex overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
+    <Tooltip tooltip={`Go to Run ${run.name || t('runName')}`} className="flex items-center overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
       <a href={`${window.origin}/runs/${run.id}`} className="overflow-hidden overflow-ellipsis">
         {run.name}{' '}
       </a>

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -31,6 +31,7 @@ import {
   NEUROGLANCER_DOC_LINK,
   REPORT_LINKS,
 } from '../Layout/constants'
+import { Tooltip } from '../Tooltip'
 import { CryoETHomeLink } from '../Layout/CryoETHomeLink'
 import { NeuroglancerBanner } from './NeuroglancerBanner'
 import { getTutorialSteps } from './steps'
@@ -410,12 +411,14 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
 
   const helperText = 'text-xs text-[#767676] font-normal'
   const activeBreadcrumbText = (
-    <a href={`${window.origin}/runs/${run.id}`}>
-      {run.name}{' '}
-      <span className="text-sds-color-primitive-common-white opacity-60">
-        (#RN-{run.id})
-      </span>
-    </a>
+    <Tooltip tooltip={run.name || t('runName')}>
+      <a href={`${window.origin}/runs/${run.id}`}>
+        {run.name}{' '}
+        <span className="text-sds-color-primitive-common-white opacity-60">
+          (#RN-{run.id})
+        </span>
+      </a>
+    </Tooltip>
   )
 
   return (

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -412,7 +412,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
 
   const helperText = 'text-xs text-[#767676] font-normal'
   const activeBreadcrumbText = (
-    <Tooltip tooltip={run.name || t('runName')} className="flex overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
+    <Tooltip tooltip={`Go to ${run.name || t('runName')}`} className="flex overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
       <a href={`${window.origin}/runs/${run.id}`} className="overflow-hidden overflow-ellipsis">
         {run.name}{' '}
       </a>

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -412,13 +412,13 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
 
   const helperText = 'text-xs text-[#767676] font-normal'
   const activeBreadcrumbText = (
-    <Tooltip tooltip={run.name || t('runName')}>
-      <a href={`${window.origin}/runs/${run.id}`}>
+    <Tooltip tooltip={run.name || t('runName')} className="flex overflow-ellipsis overflow-hidden whitespace-nowrap max-w-[12.5rem]">
+      <a href={`${window.origin}/runs/${run.id}`} className="overflow-hidden overflow-ellipsis">
         {run.name}{' '}
-        <span className="text-sds-color-primitive-common-white opacity-60">
-          (#RN-{run.id})
-        </span>
       </a>
+      <span className="text-sds-color-primitive-common-white opacity-60 ml-1">
+        (#RN-{run.id})
+      </span>
     </Tooltip>
   )
 

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -417,7 +417,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
         {run.name}{' '}
       </a>
       <span className="text-sds-color-primitive-common-white opacity-60 ml-1">
-        (#RN-{run.id})
+        (RN-{run.id})
       </span>
     </Tooltip>
   )

--- a/frontend/packages/data-portal/app/routes/view.runs.$id.tsx
+++ b/frontend/packages/data-portal/app/routes/view.runs.$id.tsx
@@ -3,7 +3,6 @@
 import { type LoaderFunctionArgs } from '@remix-run/server-runtime'
 import { lazy, Suspense } from 'react'
 import { typedjson } from 'remix-typedjson'
-import { makeThemeOptions, SDSDarkAppTheme } from '@czi-sds/components'
 
 import { apolloClientV2 } from 'app/apollo.server'
 import { QueryParams } from 'app/constants/query'


### PR DESCRIPTION
Issue [#CC-360](https://metacell.atlassian.net/browse/CC-360)
Problem: Update styling for going back to run and back to dataset
Solution: 
1. Update hover style for dataset breadcrumb in neuroglancer
2. Add tooltip over run name
3. Change style for run name

Result: 
![image](https://github.com/user-attachments/assets/dc486416-f38a-4276-ab1b-6eff40cc1149)
![image](https://github.com/user-attachments/assets/82f6cbd6-62db-4408-aa3f-dcdb472b6d07)
