### PR TITLE
feat: use responsive sizes in header bar

### DIFF
--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -170,7 +170,7 @@ export function Breadcrumbs({
 
   const buildNeuroglancerBreadcrumb = () => {
     const neuroglancerChevronIcon = (
-      <SmallChevronRightIcon className="hidden lg:block w-[8px] h-[8px] shrink-0 text-[#999] fill-[#999]" />
+      <SmallChevronRightIcon className="w-[8px] h-[8px] shrink-0 text-[#999] fill-[#999]" />
     )
     return (
       <div className="flex flex-row gap-sds-s text-dark-sds-color-primitive-gray-500 fill-[#999] font-normal text-sds-body-s-400-wide leading-sds-body-s items-center whitespace-nowrap content-start">
@@ -211,7 +211,7 @@ export function Breadcrumbs({
     <div
       className={cns(
         'flex-col flex-auto gap-1',
-        variant === 'neuroglancer' ? 'hidden md:flex' : 'flex',
+        variant === 'neuroglancer' ? 'hidden lg:flex' : 'flex',
       )}
       data-testid={TestIds.Breadcrumbs}
     >

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -417,7 +417,7 @@ function ViewerPage({ run, tomogram }: { run: any; tomogram: any }) {
   const activeBreadcrumbText = (
     <Tooltip
       tooltip={`Go to Run ${run.name || t('runName')}`}
-      className="flex items-center truncate max-w-0 md:max-w-[8rem] lg:max-w-[12rem] 2xl:max-w-[20rem]"
+      className="flex items-center truncate max-w-0 lg:max-w-[12rem] 2xl:max-w-[20rem]"
     >
       <a href={`${window.origin}/runs/${run.id}`} className="truncate">
         {run.name}{' '}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ce311f57-3562-4963-b8dd-54f6164fd229)
![image](https://github.com/user-attachments/assets/7bcda9fb-9640-4aef-9246-b8935c83ed8d)

Only shows breadcrumb on lg+ device, see sizes at https://tailwindcss.com/docs/responsive-design
Right now the sizes have two increments after this