### PR TITLE
CC-392 Our styling changes to the header accidentally changed the main page header in the portal

### DIFF
--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -50,16 +50,16 @@ export const MenuDropdown = forwardRef<
 
     const iconStyles = {
       standard: anchorEl
-        ? '!fill-sds-color-primitive-common-white'
-        : '!fill-sds-color-primitive-gray-400 group-hover:!fill-sds-color-primitive-common-white',
+        ? '!text-light-sds-color-primitive-gray-400'
+        : '!text-light-sds-color-primitive-gray-400 group-hover:!text-light-sds-color-primitive-gray-50',
       outlined: '!text-[#A2C9FF]',
       filled: '!fill-sds-color-primitive-common-white',
     }
 
     const textStyles = {
       standard: anchorEl
-        ? 'text-sds-color-primitive-common-white'
-        : 'text-sds-color-primitive-gray-400 group-hover:text-sds-color-primitive-common-white',
+        ? 'text-light-sds-color-primitive-gray-400'
+        : 'text-light-sds-color-primitive-gray-400 group-hover:text-light-sds-color-primitive-gray-50',
       outlined: '!text-[#A2C9FF]',
       filled: '!fill-sds-color-primitive-common-white',
     }
@@ -79,10 +79,7 @@ export const MenuDropdown = forwardRef<
               ref={menuRef}
               className={cns(
                 'font-semibold',
-                textStyles[variant],
-                anchorEl
-                  ? 'text-sds-color-primitive-common-white'
-                  : 'text-sds-color-primitive-gray-400 group-hover:text-sds-color-primitive-common-white',
+                textStyles[variant]
               )}
             >
               {title}
@@ -93,9 +90,7 @@ export const MenuDropdown = forwardRef<
               sdsSize="xs"
               className={cns(
                 iconStyles[variant],
-                anchorEl
-                  ? '!w-[10px] !h-[10px] !fill-sds-color-primitive-common-white'
-                  : '!w-[10px] !h-[10px] !fill-sds-color-primitive-gray-400 group-hover:!fill-sds-color-primitive-common-white',
+                '!w-[10px] !h-[10px]'
               )}
             />
           </button>

--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -77,10 +77,7 @@ export const MenuDropdown = forwardRef<
           >
             <span
               ref={menuRef}
-              className={cns(
-                'font-semibold',
-                textStyles[variant]
-              )}
+              className={cns('font-semibold', textStyles[variant])}
             >
               {title}
             </span>
@@ -88,10 +85,7 @@ export const MenuDropdown = forwardRef<
             <Icon
               sdsIcon={anchorEl ? 'ChevronUp' : 'ChevronDown'}
               sdsSize="xs"
-              className={cns(
-                iconStyles[variant],
-                '!w-[10px] !h-[10px]'
-              )}
+              className={cns(iconStyles[variant], '!w-[10px] !h-[10px]')}
             />
           </button>
         ) : (


### PR DESCRIPTION
Issue [#CC-392](https://metacell.atlassian.net/browse/CC-392)
Problem: Our styling changes to the header accidentally changed the main page header in the portal
Solution: 
1. Make change to menu dropdown ui

Result: 

https://github.com/user-attachments/assets/a5b0d025-427e-4845-a2d0-41a50ee827a5

