### PR TITLE
fix: correct styling of neuroglancer viewer header

### DIFF
--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -13,39 +13,6 @@ export type MenuDropdownRef = {
   closeMenu: () => void
 }
 
-const MENU_STYLES = {
-  button: {
-    standard: {
-      default: '!p-0',
-    },
-    outlined: {
-      default: 'border px-3.5 py-1.5 rounded-full',
-      active: 'border-white',
-      inactive: 'border-black',
-    },
-  },
-  text: {
-    standard: {
-      active: 'text-light-sds-color-primitive-gray-50',
-      inactive: 'text-light-sds-color-primitive-gray-400',
-    },
-    outlined: {
-      active: 'text-black',
-      inactive: 'text-dark-sds-color-primitive-gray-600',
-    },
-  },
-  icon: {
-    standard: {
-      active: '!fill-light-sds-color-primitive-gray-50',
-      inactive: '!fill-light-sds-color-primitive-gray-400',
-    },
-    outlined: {
-      active: '!fill-black',
-      inactive: '!fill-dark-sds-color-primitive-gray-600',
-    },
-  },
-}
-
 export const MenuDropdown = forwardRef<
   MenuDropdownRef,
   {
@@ -146,6 +113,22 @@ export const MenuDropdown = forwardRef<
       )
     }
 
+    const buildIconOnlyMenuButton = () => {
+      return (
+        <button
+          onClick={() => setAnchorEl(menuRef.current)}
+          type="button"
+          className={
+            anchorEl
+              ? '!fill-light-sds-color-primitive-gray-50'
+              : '!fill-light-sds-color-primitive-gray-500 group-hover:!fill-light-sds-color-primitive-gray-50'
+          }
+        >
+          <span ref={menuRef}>{buttonElement}</span>
+        </button>
+      )
+    }
+
     const buildMenuButtonVariations = {
       standard: buildStandardMenuButton,
       outlined: buildOutlinedMenuButton,
@@ -153,7 +136,9 @@ export const MenuDropdown = forwardRef<
 
     return (
       <div className={cns(className, 'group')}>
-        {title ? buildMenuButtonVariations[variant]() : buttonElement}
+        {title
+          ? buildMenuButtonVariations[variant]()
+          : buildIconOnlyMenuButton()}
 
         <Menu
           anchorEl={anchorEl}

--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -78,7 +78,7 @@ export const MenuDropdown = forwardRef<
     const buildStandardMenuButton = () => {
       return (
         <button
-          className="!p-0 flex items-center gap-2 group"
+          className="!p-0 flex items-center gap-2"
           onClick={() => setAnchorEl(menuRef.current)}
           type="button"
         >
@@ -111,7 +111,12 @@ export const MenuDropdown = forwardRef<
     const buildOutlinedMenuButton = () => {
       return (
         <button
-          className="border border-[#A2C9FF] px-3.5 py-1.5 rounded-full flex items-center gap-2 group"
+          className={cns(
+            'border px-3.5 py-1.5 rounded-full flex items-center gap-2',
+            anchorEl
+              ? 'border-dark-sds-color-primitive-blue-700 bg-dark-sds-color-primitive-blue-700'
+              : 'border-dark-sds-color-primitive-blue-600 group-hover:border-dark-sds-color-primitive-blue-700 group-hover:bg-dark-sds-color-primitive-blue-700',
+          )}
           onClick={() => setAnchorEl(menuRef.current)}
           type="button"
         >
@@ -122,7 +127,7 @@ export const MenuDropdown = forwardRef<
 
               anchorEl
                 ? 'text-light-sds-color-primitive-gray-900'
-                : 'text-dark-sds-color-primitive-blue-600 group-hover:text-light-sds-color-primitive-gray-50',
+                : 'text-dark-sds-color-primitive-blue-600 group-hover:text-light-sds-color-primitive-gray-900',
             )}
           >
             {title}
@@ -134,7 +139,7 @@ export const MenuDropdown = forwardRef<
             className={cns(
               anchorEl
                 ? '!w-[10px] !h-[10px] !fill-light-sds-color-primitive-gray-900'
-                : '!w-[10px] !h-[10px] !fill-dark-sds-color-primitive-blue-600 group-hover:!fill-light-sds-color-primitive-gray-50',
+                : '!w-[10px] !h-[10px] !fill-dark-sds-color-primitive-blue-600 group-hover:!fill-light-sds-color-primitive-gray-900',
             )}
           />
         </button>
@@ -143,11 +148,11 @@ export const MenuDropdown = forwardRef<
 
     const buildMenuButtonVariations = {
       standard: buildStandardMenuButton,
-      outlined: buildOutlinedMenuButton
+      outlined: buildOutlinedMenuButton,
     }
 
     return (
-      <div className={className}>
+      <div className={cns(className, 'group')}>
         {title ? buildMenuButtonVariations[variant]() : buttonElement}
 
         <Menu

--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -75,62 +75,47 @@ export const MenuDropdown = forwardRef<
       closeMenu: () => setAnchorEl(null),
     }))
 
-    return (
-      <div className={cns(className, 'group')}>
-        {title ? (
-          <button
+    const buildStandardMenuButton = () => {
+      return (
+        <button
+          className="!p-0 flex items-center gap-2 group"
+          onClick={() => setAnchorEl(menuRef.current)}
+          type="button"
+        >
+          <span
+            ref={menuRef}
             className={cns(
-              'flex items-center gap-2',
-              MENU_STYLES.button[variant].default,
-              variant === 'outlined' &&
-                (anchorEl
-                  ? MENU_STYLES.button[variant].active
-                  : cns(
-                      MENU_STYLES.button[variant].inactive,
-                      `group-hover:${MENU_STYLES.button[variant].active}`,
-                    )),
-            )}
-            onClick={() => setAnchorEl(menuRef.current)}
-            type="button"
-          >
-            <span
-              ref={menuRef}
-              className={cns(
-                'font-semibold',
-                anchorEl
-                  ? MENU_STYLES.text[variant].active
-                  : cns(
-                      MENU_STYLES.text[variant].inactive,
-                      `group-hover:${MENU_STYLES.text[variant].active}`,
-                    ),
-              )}
-            >
-              {title}
-            </span>
+              'font-semibold',
 
-            <Icon
-              sdsIcon={anchorEl ? 'ChevronUp' : 'ChevronDown'}
-              sdsSize="xs"
-              className={cns(
-                '!w-[10px] !h-[10px]',
-                anchorEl
-                  ? MENU_STYLES.icon[variant].active
-                  : cns(
-                      MENU_STYLES.icon[variant].inactive,
-                      `group-hover:${MENU_STYLES.icon[variant].active}`,
-                    ),
-              )}
-            />
-          </button>
-        ) : (
-          <button
-            onClick={() => setAnchorEl(menuRef.current)}
-            type="button"
-            className="text-[#999] hover:text-sds-color-primitive-common-white"
+              anchorEl
+                ? 'text-light-sds-color-primitive-gray-50'
+                : 'text-light-sds-color-primitive-gray-400 group-hover:text-light-sds-color-primitive-gray-50',
+            )}
           >
-            <span ref={menuRef}>{buttonElement}</span>
-          </button>
-        )}
+            {title}
+          </span>
+
+          <Icon
+            sdsIcon={anchorEl ? 'ChevronUp' : 'ChevronDown'}
+            sdsSize="xs"
+            className={cns(
+              anchorEl
+                ? '!w-[10px] !h-[10px] !fill-light-sds-color-primitive-gray-50'
+                : '!w-[10px] !h-[10px] !fill-light-sds-color-primitive-gray-400 group-hover:!fill-light-sds-color-primitive-gray-50',
+            )}
+          />
+        </button>
+      )
+    }
+
+    const buildMenuButtonVariations = {
+      standard: buildStandardMenuButton,
+      outlined: buildStandardMenuButton
+    }
+
+    return (
+      <div className={className}>
+        {title ? buildMenuButtonVariations[variant]() : buttonElement}
 
         <Menu
           anchorEl={anchorEl}

--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -108,9 +108,42 @@ export const MenuDropdown = forwardRef<
       )
     }
 
+    const buildOutlinedMenuButton = () => {
+      return (
+        <button
+          className="border border-[#A2C9FF] px-3.5 py-1.5 rounded-full flex items-center gap-2 group"
+          onClick={() => setAnchorEl(menuRef.current)}
+          type="button"
+        >
+          <span
+            ref={menuRef}
+            className={cns(
+              'font-semibold',
+
+              anchorEl
+                ? 'text-light-sds-color-primitive-gray-900'
+                : 'text-dark-sds-color-primitive-blue-600 group-hover:text-light-sds-color-primitive-gray-50',
+            )}
+          >
+            {title}
+          </span>
+
+          <Icon
+            sdsIcon={anchorEl ? 'ChevronUp' : 'ChevronDown'}
+            sdsSize="xs"
+            className={cns(
+              anchorEl
+                ? '!w-[10px] !h-[10px] !fill-light-sds-color-primitive-gray-900'
+                : '!w-[10px] !h-[10px] !fill-dark-sds-color-primitive-blue-600 group-hover:!fill-light-sds-color-primitive-gray-50',
+            )}
+          />
+        </button>
+      )
+    }
+
     const buildMenuButtonVariations = {
       standard: buildStandardMenuButton,
-      outlined: buildStandardMenuButton
+      outlined: buildOutlinedMenuButton
     }
 
     return (

--- a/frontend/packages/data-portal/app/components/MenuDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/MenuDropdown.tsx
@@ -13,11 +13,44 @@ export type MenuDropdownRef = {
   closeMenu: () => void
 }
 
+const MENU_STYLES = {
+  button: {
+    standard: {
+      default: '!p-0',
+    },
+    outlined: {
+      default: 'border px-3.5 py-1.5 rounded-full',
+      active: 'border-white',
+      inactive: 'border-black',
+    },
+  },
+  text: {
+    standard: {
+      active: 'text-light-sds-color-primitive-gray-50',
+      inactive: 'text-light-sds-color-primitive-gray-400',
+    },
+    outlined: {
+      active: 'text-black',
+      inactive: 'text-dark-sds-color-primitive-gray-600',
+    },
+  },
+  icon: {
+    standard: {
+      active: '!fill-light-sds-color-primitive-gray-50',
+      inactive: '!fill-light-sds-color-primitive-gray-400',
+    },
+    outlined: {
+      active: '!fill-black',
+      inactive: '!fill-dark-sds-color-primitive-gray-600',
+    },
+  },
+}
+
 export const MenuDropdown = forwardRef<
   MenuDropdownRef,
   {
     children: ReactNode
-    variant?: 'standard' | 'outlined' | 'filled'
+    variant?: 'standard' | 'outlined'
     className?: string
     title: ReactNode
     buttonElement?: ReactNode
@@ -42,42 +75,35 @@ export const MenuDropdown = forwardRef<
       closeMenu: () => setAnchorEl(null),
     }))
 
-    const variantStyles = {
-      standard: '!p-0',
-      outlined: 'border border-[#A2C9FF] px-3.5 py-1.5 rounded-full',
-      filled: 'bg-[#2573F4] px-3.5 py-1.5 rounded-full',
-    }
-
-    const iconStyles = {
-      standard: anchorEl
-        ? '!text-light-sds-color-primitive-gray-400'
-        : '!text-light-sds-color-primitive-gray-400 group-hover:!text-light-sds-color-primitive-gray-50',
-      outlined: '!text-[#A2C9FF]',
-      filled: '!fill-sds-color-primitive-common-white',
-    }
-
-    const textStyles = {
-      standard: anchorEl
-        ? 'text-light-sds-color-primitive-gray-400'
-        : 'text-light-sds-color-primitive-gray-400 group-hover:text-light-sds-color-primitive-gray-50',
-      outlined: '!text-[#A2C9FF]',
-      filled: '!fill-sds-color-primitive-common-white',
-    }
-
     return (
-      <div className={className}>
+      <div className={cns(className, 'group')}>
         {title ? (
           <button
             className={cns(
-              'flex items-center gap-2 group',
-              variantStyles[variant],
+              'flex items-center gap-2',
+              MENU_STYLES.button[variant].default,
+              variant === 'outlined' &&
+                (anchorEl
+                  ? MENU_STYLES.button[variant].active
+                  : cns(
+                      MENU_STYLES.button[variant].inactive,
+                      `group-hover:${MENU_STYLES.button[variant].active}`,
+                    )),
             )}
             onClick={() => setAnchorEl(menuRef.current)}
             type="button"
           >
             <span
               ref={menuRef}
-              className={cns('font-semibold', textStyles[variant])}
+              className={cns(
+                'font-semibold',
+                anchorEl
+                  ? MENU_STYLES.text[variant].active
+                  : cns(
+                      MENU_STYLES.text[variant].inactive,
+                      `group-hover:${MENU_STYLES.text[variant].active}`,
+                    ),
+              )}
             >
               {title}
             </span>
@@ -85,7 +111,15 @@ export const MenuDropdown = forwardRef<
             <Icon
               sdsIcon={anchorEl ? 'ChevronUp' : 'ChevronDown'}
               sdsSize="xs"
-              className={cns(iconStyles[variant], '!w-[10px] !h-[10px]')}
+              className={cns(
+                '!w-[10px] !h-[10px]',
+                anchorEl
+                  ? MENU_STYLES.icon[variant].active
+                  : cns(
+                      MENU_STYLES.icon[variant].inactive,
+                      `group-hover:${MENU_STYLES.icon[variant].active}`,
+                    ),
+              )}
             />
           </button>
         ) : (

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -724,7 +724,7 @@ function ViewerPage({
             >
               <CustomDropdownSection title="About">
                 {ABOUT_LINKS.map((option) => (
-                  <MenuItemLink key={option.label} to={option.link}>
+                  <MenuItemLink key={option.label} to={option.link} target="_blank">
                     {t(option.label)}
                   </MenuItemLink>
                 ))}

--- a/frontend/packages/data-portal/app/components/Run/steps.tsx
+++ b/frontend/packages/data-portal/app/components/Run/steps.tsx
@@ -117,7 +117,7 @@ export const getTutorialSteps: () => Step[] = () => [
       '.neuroglancer-layer-group-viewer:has(.neuroglancer-rendered-data-panel)',
     ),
     title: 'Essential controls',
-    placement: 'left',
+    placement: 'left-start',
     disableBeacon: true,
     content: (
       <StepContent variant="simple">
@@ -142,7 +142,7 @@ export const getTutorialSteps: () => Step[] = () => [
       '.neuroglancer-layer-group-viewer:has(.neuroglancer-rendered-data-panel)',
     ),
     title: 'Keyboard shortcuts',
-    placement: 'left',
+    placement: 'left-start',
     disableBeacon: true,
     content: (
       <StepContent variant="simple">

--- a/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/common/CustomDropdown.tsx
@@ -8,7 +8,7 @@ import { cns } from 'app/utils/cns'
 type CustomDropdownProps = {
   className?: string
   title?: string
-  variant?: 'standard' | 'outlined' | 'filled'
+  variant?: 'standard' | 'outlined'
   buttonElement?: ReactNode
   children: ReactNode
 }

--- a/frontend/packages/data-portal/app/components/icons/InfoIcon.tsx
+++ b/frontend/packages/data-portal/app/components/icons/InfoIcon.tsx
@@ -7,12 +7,11 @@ export function InfoIcon(props: IconProps) {
       width="24"
       height="24"
       viewBox="0 0 24 24"
-      fill="none"
       {...props}
     >
       <path
+        fillRule="evenodd"
         d="M11 18H13V16H11V18ZM12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20ZM12 6C9.79 6 8 7.79 8 10H10C10 8.9 10.9 8 12 8C13.1 8 14 8.9 14 10C14 12 11 11.75 11 15H13C13 12.75 16 12.5 16 10C16 7.79 14.21 6 12 6Z"
-        fill="currentColor"
       />
     </svg>
   )


### PR DESCRIPTION
Mainly updates how we built the menu dropdown to accomodate styling much easier, was buggy applying it with all the cns calls otherwise. Also two small fixes to open links in the about menu in a new tab, and to place the tour steps so they don't get cut off