### PR TITLE
Feat: improve mobile appearance

### DIFF
--- a/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
+++ b/frontend/packages/data-portal/app/components/Breadcrumbs.tsx
@@ -176,7 +176,7 @@ export function Breadcrumbs({
       <div className="flex flex-row gap-sds-s text-dark-sds-color-primitive-gray-500 fill-[#999] font-normal text-sds-body-s-400-wide leading-sds-body-s items-center whitespace-nowrap content-start">
         <Tooltip
           tooltip={`Go to Dataset ${data.title}`}
-          className="truncate max-w-0 lg:max-w-[10rem] xl:max-w-[16rem] 2xl:max-w-xl"
+          className="truncate max-w-0 lg:max-w-[8rem] xl:max-w-[16rem] 2xl:max-w-xl"
         >
           <Breadcrumb
             text={data.title}

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -553,11 +553,12 @@ function ViewerPage({
       <nav
         className={cns(
           'bg-sds-color-primitive-common-black text-sds-color-primitive-common-white',
-          'flex flex-shrink-0 items-center pt-1 pb-20',
-          'sticky top-0 z-30 max-h-12 flex-col md:flex-row md:pb-1',
+          'flex flex-shrink-0 pt-1 pb-20 flex-col',
+          'sticky top-0 z-30 max-h-12 items-start',
+          'sm:flex-row sm:pb-1 sm:items-center',
         )}
       >
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-1 md:gap-4">
           <CryoETHomeLink textSize="text-sm" />
           <Breadcrumbs
             variant="neuroglancer"
@@ -568,7 +569,7 @@ function ViewerPage({
         {/* Add empty space to push content to right */}
         <div className="basis-sds-xxl flex-grow md:mr-sds-xxl" />
         <div className="flex basis-auto flex-shrink-0">
-          <div className="flex items-center pt-1 gap-0 md:gap-1 md:pt-0">
+          <div className="flex items-center pt-1 gap-[1px] sm:gap-1 sm:pt-0">
             {shouldShowAnnotationDropdown && (
               <CustomDropdown title="Annotations" variant="outlined">
                 <CustomDropdownSection title="Show annotations for deposition">
@@ -719,7 +720,7 @@ function ViewerPage({
               Share
             </Button>
             <CustomDropdown
-              className="w-4 h-11 pl-1 py-3 md:w-11 md:px-3"
+              className="w-4 h-11 pl-1 py-3 sm:w-11 sm:px-3"
               buttonElement={<InfoIcon className="w-5 h-5" />}
             >
               <CustomDropdownSection title="About">

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -553,8 +553,8 @@ function ViewerPage({
       <nav
         className={cns(
           'bg-sds-color-primitive-common-black text-sds-color-primitive-common-white',
-          'flex flex-shrink-0 items-center py-1',
-          'sticky top-0 z-30 max-h-12',
+          'flex flex-shrink-0 items-center pt-1 pb-20',
+          'sticky top-0 z-30 max-h-12 flex-col md:flex-row md:pb-1',
         )}
       >
         <div className="flex items-center gap-4">
@@ -568,7 +568,7 @@ function ViewerPage({
         {/* Add empty space to push content to right */}
         <div className="basis-sds-xxl flex-grow md:mr-sds-xxl" />
         <div className="flex basis-auto flex-shrink-0">
-          <div className="flex items-center gap-1">
+          <div className="flex items-center pt-1 gap-0 md:gap-1 md:pt-0">
             {shouldShowAnnotationDropdown && (
               <CustomDropdown title="Annotations" variant="outlined">
                 <CustomDropdownSection title="Show annotations for deposition">
@@ -719,7 +719,7 @@ function ViewerPage({
               Share
             </Button>
             <CustomDropdown
-              className="w-11 h-11 p-3"
+              className="w-4 h-11 pl-1 py-3 md:w-11 md:px-3"
               buttonElement={<InfoIcon className="w-5 h-5" />}
             >
               <CustomDropdownSection title="About">

--- a/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Run/ViewerPage.tsx
@@ -553,9 +553,9 @@ function ViewerPage({
       <nav
         className={cns(
           'bg-sds-color-primitive-common-black text-sds-color-primitive-common-white',
-          'flex flex-shrink-0 pt-1 pb-20 flex-col',
-          'sticky top-0 z-30 max-h-12 items-start',
-          'sm:flex-row sm:pb-1 sm:items-center',
+          'flex flex-shrink-0 py-1 flex-col',
+          'sticky top-0 z-30 max-h-20 items-start',
+          'sm:flex-row sm:max-h-12 sm:items-center',
         )}
       >
         <div className="flex items-center gap-1 md:gap-4">


### PR DESCRIPTION
This should allow seeing the header menu dropdowns on more mobile devices. The help icon might be hidden in some cases, but at the least the main action dropdowns should be there.

It's not a 100% solution, but should be good enough that if someone clicks on a link to this on mobile it is usable for them
![image](https://github.com/user-attachments/assets/c10eac21-d618-416b-92bb-1ad760cb6d3a)
