### PR TITLE
fix: handle breakage from feature flags in URL truncation

### DIFF
--- a/frontend/packages/data-portal/app/components/Link/Link.tsx
+++ b/frontend/packages/data-portal/app/components/Link/Link.tsx
@@ -6,7 +6,11 @@ import {
   DASHED_UNDERLINED_CLASSES,
 } from 'app/utils/classNames'
 import { cnsNoMerge } from 'app/utils/cns'
-import { isExternalUrl, preserveFeatureFlagParams } from 'app/utils/url'
+import {
+  isExternalUrl,
+  isNeuroglancerUrl,
+  preserveFeatureFlagParams,
+} from 'app/utils/url'
 
 export type VariantLinkProps = LinkProps & {
   newTab?: boolean
@@ -32,7 +36,7 @@ function BaseLink(
 
   // Preserve feature flag parameters for internal links
   const url =
-    typeof originalUrl === 'string'
+    typeof originalUrl === 'string' && !isNeuroglancerUrl(originalUrl)
       ? preserveFeatureFlagParams(originalUrl, searchParams)
       : originalUrl
 

--- a/frontend/packages/data-portal/app/utils/url.ts
+++ b/frontend/packages/data-portal/app/utils/url.ts
@@ -17,6 +17,13 @@ export function isExternalUrl(url: string): boolean {
   }
 }
 /**
+ * Checks if the URL is a neuroglancer URL
+ */
+export function isNeuroglancerUrl(url: string): boolean {
+  return url.includes('/#!')
+}
+
+/**
  * Wrapper over the URL constructor with additional functionality. URLs that
  * cannot be constructor without a base will automatically have the base
  * `http://tmp.com` added to the URL. This is to ensure URLs can be created from


### PR DESCRIPTION
it was causing the neuroglancer URL to have nothing in it so neuroglancer was getting a blank JSON state

Going to merge this for now just to allow using the viewer, but it seems there might be a problem now if you hit back to go out of the viewer. Might need to look at that separately.

Also might want a better detection for neuroglancer URLs, though I'm not sure how much is fixed to be in a URL