### PR TITLE
CC-449 Apply styling from figma to the tomogram select dropdown

### DIFF
--- a/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.test.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.test.tsx
@@ -26,10 +26,10 @@ describe('<NeuroglancerDropdown />', () => {
 })
 
 describe('<NeuroglancerDropdownOption />', () => {
-  it('should render children and handle clicks', async () => {
+  it('should render children, title, subtitle and handle clicks', async () => {
     const handleClick = jest.fn()
     render(
-      <NeuroglancerDropdownOption onSelect={handleClick}>
+      <NeuroglancerDropdownOption title="Option title" onSelect={handleClick}>
         Option Text
       </NeuroglancerDropdownOption>,
     )
@@ -41,7 +41,7 @@ describe('<NeuroglancerDropdownOption />', () => {
 
   it('should show check icon when selected', () => {
     const { container } = render(
-      <NeuroglancerDropdownOption selected>
+      <NeuroglancerDropdownOption title="Option title" selected>
         Selected Option
       </NeuroglancerDropdownOption>,
     )
@@ -52,7 +52,7 @@ describe('<NeuroglancerDropdownOption />', () => {
 
   it('should not show check icon when not selected', () => {
     const { container } = render(
-      <NeuroglancerDropdownOption>
+      <NeuroglancerDropdownOption title="Option title">
         Unselected Option
       </NeuroglancerDropdownOption>,
     )
@@ -61,5 +61,10 @@ describe('<NeuroglancerDropdownOption />', () => {
     expect(screen.getByText('Unselected Option')).not.toHaveClass(
       'font-semibold',
     )
+  })
+
+  it('should not render subtitle if not provided', () => {
+    render(<NeuroglancerDropdownOption title="Option title" />)
+    expect(screen.queryByText('Subtitle')).not.toBeInTheDocument()
   })
 })

--- a/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.test.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.test.tsx
@@ -29,21 +29,20 @@ describe('<NeuroglancerDropdownOption />', () => {
   it('should render children, title, subtitle and handle clicks', async () => {
     const handleClick = jest.fn()
     render(
-      <NeuroglancerDropdownOption title="Option title" onSelect={handleClick}>
-        Option Text
-      </NeuroglancerDropdownOption>,
+      <NeuroglancerDropdownOption
+        title="Option Title"
+        onSelect={handleClick}
+      />,
     )
 
-    const option = screen.getByText('Option Text')
+    const option = screen.getByText('Option Title')
     await userEvent.click(option)
     expect(handleClick).toHaveBeenCalled()
   })
 
   it('should show check icon when selected', () => {
     const { container } = render(
-      <NeuroglancerDropdownOption title="Option title" selected>
-        Selected Option
-      </NeuroglancerDropdownOption>,
+      <NeuroglancerDropdownOption title="Selected Option" selected />,
     )
 
     expect(container.querySelector('svg')).toBeInTheDocument() // eslint-disable-line testing-library/no-node-access, testing-library/no-container
@@ -52,9 +51,7 @@ describe('<NeuroglancerDropdownOption />', () => {
 
   it('should not show check icon when not selected', () => {
     const { container } = render(
-      <NeuroglancerDropdownOption title="Option title">
-        Unselected Option
-      </NeuroglancerDropdownOption>,
+      <NeuroglancerDropdownOption title="Unselected Option" />,
     )
 
     expect(container.querySelector('svg')).toBeNull() // eslint-disable-line testing-library/no-node-access, testing-library/no-container
@@ -63,8 +60,10 @@ describe('<NeuroglancerDropdownOption />', () => {
     )
   })
 
-  it('should not render subtitle if not provided', () => {
-    render(<NeuroglancerDropdownOption title="Option title" />)
-    expect(screen.queryByText('Subtitle')).not.toBeInTheDocument()
+  it('should render subtitle if provided', () => {
+    render(
+      <NeuroglancerDropdownOption title="Option title" subtitle="Subtitle" />,
+    )
+    expect(screen.getByText('Subtitle')).toBeInTheDocument()
   })
 })

--- a/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
@@ -18,8 +18,8 @@ export function NeuroglancerDropdownOption({
 }: ComponentProps<typeof MenuItem> & {
   selected?: boolean
   onClick?: () => void
-  title?: any
-  subtitle?: any
+  title: React.ReactNode
+  subtitle?: React.ReactNode
 }) {
   return (
     <MenuItem
@@ -33,16 +33,18 @@ export function NeuroglancerDropdownOption({
             <Icon sdsIcon="Check" sdsSize="s" className="!fill-[#0B68F8]" />
           ) : null}
         </div>
-        <div className={cns(selected && 'font-semibold', "flex flex-col w-full")}>
-          <span className={cns(selected && 'font-semibold')}>{title}</span>
-          {subtitle && <span
-            className={cns(
-              "text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600 !font-normal",
-              props.disabled && 'text-light-sds-color-primitive-gray-300',
-            )}
-          >
-            {subtitle}
-          </span>}
+        <div className='flex justify-between w-full'>
+          <div className='flex flex-col'>
+            <span className={cns(selected && 'font-semibold')}>{title}</span>
+            {subtitle && <span
+              className={cns(
+                "text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600",
+                props.disabled && 'text-light-sds-color-primitive-gray-300',
+              )}
+            >
+              {subtitle}
+            </span>}
+          </div>
           {children}
         </div>
       </div>

--- a/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
@@ -33,17 +33,19 @@ export function NeuroglancerDropdownOption({
             <Icon sdsIcon="Check" sdsSize="s" className="!fill-[#0B68F8]" />
           ) : null}
         </div>
-        <div className='flex justify-between w-full'>
-          <div className='flex flex-col'>
+        <div className="flex justify-between w-full">
+          <div className="flex flex-col">
             <span className={cns(selected && 'font-semibold')}>{title}</span>
-            {subtitle && <span
-              className={cns(
-                "text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600",
-                props.disabled && 'text-light-sds-color-primitive-gray-300',
-              )}
-            >
-              {subtitle}
-            </span>}
+            {subtitle && (
+              <span
+                className={cns(
+                  'text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600',
+                  props.disabled && 'text-light-sds-color-primitive-gray-300',
+                )}
+              >
+                {subtitle}
+              </span>
+            )}
           </div>
           {children}
         </div>

--- a/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/NeuroglancerDropdown.tsx
@@ -12,10 +12,14 @@ export function NeuroglancerDropdownOption({
   selected,
   onSelect,
   children,
+  title,
+  subtitle,
   ...props
 }: ComponentProps<typeof MenuItem> & {
   selected?: boolean
   onClick?: () => void
+  title?: any
+  subtitle?: any
 }) {
   return (
     <MenuItem
@@ -29,14 +33,16 @@ export function NeuroglancerDropdownOption({
             <Icon sdsIcon="Check" sdsSize="s" className="!fill-[#0B68F8]" />
           ) : null}
         </div>
-        <div
-          className={cns(
-            selected && 'font-semibold',
-            'flex',
-            'flex-col',
-            'w-full',
-          )}
-        >
+        <div className={cns(selected && 'font-semibold', "flex flex-col w-full")}>
+          <span className={cns(selected && 'font-semibold')}>{title}</span>
+          {subtitle && <span
+            className={cns(
+              "text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600 !font-normal",
+              props.disabled && 'text-light-sds-color-primitive-gray-300',
+            )}
+          >
+            {subtitle}
+          </span>}
           {children}
         </div>
       </div>

--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -512,36 +512,36 @@ export function ViewerPage({
                 <NeuroglancerDropdownOption
                   selected={hasBoundingBox()}
                   onSelect={toggleBoundingBox}
+                  title={t('bbox')}
                 >
                   <div className="flex justify-between items-center">
-                    <p>{t('bbox')}</p>
                     <p className={helperText}>v</p>
                   </div>
                 </NeuroglancerDropdownOption>
                 <NeuroglancerDropdownOption
                   selected={axisLineEnabled()}
                   onSelect={toggleAxisLine}
+                  title={t('axisLines')}
                 >
                   <div className="flex justify-between items-center">
-                    <p>{t('axisLines')}</p>
                     <p className={helperText}>a</p>
                   </div>
                 </NeuroglancerDropdownOption>
                 <NeuroglancerDropdownOption
                   selected={showScaleBarEnabled()}
                   onSelect={toggleShowScaleBar}
+                  title={t('scaleBar')}
                 >
                   <div className="flex justify-between items-center">
-                    <p>{t('scaleBar')}</p>
                     <p className={helperText}>b</p>
                   </div>
                 </NeuroglancerDropdownOption>
                 <NeuroglancerDropdownOption
                   selected={showSectionsEnabled()}
                   onSelect={toggleShowSections}
+                  title={t('crossSection')}
                 >
                   <div className="flex justify-between items-center">
-                    <p>{t('crossSection')}</p>
                     <p className={helperText}>s</p>
                   </div>
                 </NeuroglancerDropdownOption>
@@ -550,9 +550,9 @@ export function ViewerPage({
                 <NeuroglancerDropdownOption
                   selected={false}
                   onSelect={handleSnapActionClick}
+                  title={t('snapAction')}
                 >
                   <div className="flex justify-between items-center">
-                    <p>{t('snapAction')}</p>
                     <p className={helperText}>z</p>
                   </div>
                 </NeuroglancerDropdownOption>

--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -406,15 +406,15 @@ export function ViewerPage({
                               ...state,
                               neuroglancer: tomogram.neuroglancerConfig
                                 ? replaceOnlyTomogram(
-                                  state.neuroglancer,
-                                  JSON.parse(
-                                    tomogram.neuroglancerConfig,
-                                  ) as NeuroglancerState,
-                                )
+                                    state.neuroglancer,
+                                    JSON.parse(
+                                      tomogram.neuroglancerConfig,
+                                    ) as NeuroglancerState,
+                                  )
                                 : replaceOnlyTomogramSource(
-                                  state.neuroglancer,
-                                  toZarr(tomogram.httpsMrcFile)!,
-                                ),
+                                    state.neuroglancer,
+                                    toZarr(tomogram.httpsMrcFile)!,
+                                  ),
                             }
                           })
                         }}
@@ -422,7 +422,8 @@ export function ViewerPage({
                         subtitle={[
                           `${IdPrefix.Tomogram}-${tomogram.id}`,
                           `${t('unitAngstrom', { value: tomogram.voxelSpacing })} (${tomogram.sizeX}, ${tomogram.sizeY}, ${tomogram.sizeZ}) px`,
-                          tomogram.alignment?.id != null && `${IdPrefix.Alignment}-${tomogram.alignment.id}`,
+                          tomogram.alignment?.id != null &&
+                            `${IdPrefix.Alignment}-${tomogram.alignment.id}`,
                         ]
                           .filter(Boolean)
                           .join(' · ')}
@@ -450,7 +451,10 @@ export function ViewerPage({
                           onSelect={() => {
                             toggleDepositions(layersOfInterest)
                           }}
-                          title={depositions?.[0].annotation?.deposition?.title || 'Deposition'}
+                          title={
+                            depositions?.[0].annotation?.deposition?.title ||
+                            'Deposition'
+                          }
                           subtitle={`${IdPrefix.Deposition}-${depositionId}`}
                         />
                       )

--- a/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
+++ b/frontend/packages/data-portal/app/components/Viewer/ViewerPage.tsx
@@ -390,50 +390,46 @@ export function ViewerPage({
           <div className="flex items-center pt-1 gap-[1px] sm:gap-1 sm:pt-0">
             {shouldShowTomogramDropdown && (
               <NeuroglancerDropdown title="Tomograms" variant="outlined">
-                {tomograms.map((tomogram) => {
-                  return (
-                    <NeuroglancerDropdownOption
-                      key={tomogram.id.toString()}
-                      selected={selectedTomogram(tomogram)}
-                      disabled={unsupportedTomogramSwitch(tomogram)}
-                      onSelect={() => {
-                        if (selectedTomogram(tomogram)) return
-                        voxelSpacing.current = tomogram.voxelSpacing
-                        alignmentId.current = tomogram.alignment?.id || 0
-                        updateState((state) => {
-                          return {
-                            ...state,
-                            neuroglancer: tomogram.neuroglancerConfig
-                              ? replaceOnlyTomogram(
+                <MenuDropdownSection title="Select tomogram">
+                  {tomograms.map((tomogram) => {
+                    return (
+                      <NeuroglancerDropdownOption
+                        key={tomogram.id.toString()}
+                        selected={selectedTomogram(tomogram)}
+                        disabled={unsupportedTomogramSwitch(tomogram)}
+                        onSelect={() => {
+                          if (selectedTomogram(tomogram)) return
+                          voxelSpacing.current = tomogram.voxelSpacing
+                          alignmentId.current = tomogram.alignment?.id || 0
+                          updateState((state) => {
+                            return {
+                              ...state,
+                              neuroglancer: tomogram.neuroglancerConfig
+                                ? replaceOnlyTomogram(
                                   state.neuroglancer,
                                   JSON.parse(
                                     tomogram.neuroglancerConfig,
                                   ) as NeuroglancerState,
                                 )
-                              : replaceOnlyTomogramSource(
+                                : replaceOnlyTomogramSource(
                                   state.neuroglancer,
                                   toZarr(tomogram.httpsMrcFile)!,
                                 ),
-                          }
-                        })
-                      }}
-                    >
-                      <span className="line-clamp-3">
-                        {getTomogramName(tomogram)}
-                      </span>
-                      <span className="text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600">
-                        {[
+                            }
+                          })
+                        }}
+                        title={getTomogramName(tomogram)}
+                        subtitle={[
                           `${IdPrefix.Tomogram}-${tomogram.id}`,
                           `${t('unitAngstrom', { value: tomogram.voxelSpacing })} (${tomogram.sizeX}, ${tomogram.sizeY}, ${tomogram.sizeZ}) px`,
-                          tomogram.alignment?.id != null &&
-                            `${IdPrefix.Alignment}-${tomogram.alignment.id}`,
+                          tomogram.alignment?.id != null && `${IdPrefix.Alignment}-${tomogram.alignment.id}`,
                         ]
                           .filter(Boolean)
                           .join(' · ')}
-                      </span>
-                    </NeuroglancerDropdownOption>
-                  )
-                })}
+                      />
+                    )
+                  })}
+                </MenuDropdownSection>
               </NeuroglancerDropdown>
             )}
             {shouldShowAnnotationDropdown && (
@@ -442,9 +438,8 @@ export function ViewerPage({
                   <NeuroglancerDropdownOption
                     selected={isAllLayerActive()}
                     onSelect={() => toggleAllDepositions()}
-                  >
-                    {t('allDepositions')}
-                  </NeuroglancerDropdownOption>
+                    title={t('allDepositions')}
+                  />
                   {Object.entries(depositionConfigs).map(
                     ([depositionId, depositions]) => {
                       const layersOfInterest = depositions.map((c) => c.name)
@@ -455,15 +450,9 @@ export function ViewerPage({
                           onSelect={() => {
                             toggleDepositions(layersOfInterest)
                           }}
-                        >
-                          <span className="line-clamp-3">
-                            {depositions?.[0].annotation?.deposition?.title ||
-                              'Deposition'}
-                          </span>
-                          <span className="text-sds-body-xxxs-400-narrow text-light-sds-color-primitive-gray-600">
-                            {IdPrefix.Deposition}-{depositionId}
-                          </span>
-                        </NeuroglancerDropdownOption>
+                          title={depositions?.[0].annotation?.deposition?.title || 'Deposition'}
+                          subtitle={`${IdPrefix.Deposition}-${depositionId}`}
+                        />
                       )
                     },
                   )}
@@ -477,53 +466,45 @@ export function ViewerPage({
                     isCurrentLayout('4panel') || isCurrentLayout('4panel-alt')
                   }
                   onSelect={() => setCurrentLayout('4panel')}
-                >
-                  {t('4panels')}
-                </NeuroglancerDropdownOption>
+                  title={t('4panels')}
+                />
                 <NeuroglancerDropdownOption
                   selected={isCurrentLayout('xy')}
                   onSelect={() => setCurrentLayout('xy')}
-                >
-                  XY
-                </NeuroglancerDropdownOption>
+                  title="XY"
+                />
                 <NeuroglancerDropdownOption
                   selected={isCurrentLayout('xz')}
                   onSelect={() => setCurrentLayout('xz')}
-                >
-                  XZ
-                </NeuroglancerDropdownOption>
+                  title="XZ"
+                />
                 <NeuroglancerDropdownOption
                   selected={isCurrentLayout('yz')}
                   onSelect={() => setCurrentLayout('yz')}
-                >
-                  YZ
-                </NeuroglancerDropdownOption>
+                  title="YZ"
+                />
                 <NeuroglancerDropdownOption
                   selected={isCurrentLayout('3d')}
                   onSelect={() => setCurrentLayout('3d')}
-                >
-                  3D
-                </NeuroglancerDropdownOption>
+                  title="3D"
+                />
               </MenuDropdownSection>
               <MenuDropdownSection title="Toggle Panels">
                 <NeuroglancerDropdownOption
                   selected={getCurrentState().savedPanelsStatus !== undefined}
                   onSelect={() => togglePanels()}
-                >
-                  {t('hideUI')}
-                </NeuroglancerDropdownOption>
+                  title={t('hideUI')}
+                />
                 <NeuroglancerDropdownOption
                   selected={isTopBarVisible()}
                   onSelect={() => toggleTopBar()}
-                >
-                  {t('showTopLayerBar')}
-                </NeuroglancerDropdownOption>
+                  title={t('showTopLayerBar')}
+                />
                 <NeuroglancerDropdownOption
                   selected={isDimensionPanelVisible()}
                   onSelect={toggleOrMakeDimensionPanel}
-                >
-                  {t('showPositionSelector')}
-                </NeuroglancerDropdownOption>
+                  title={t('showPositionSelector')}
+                />
               </MenuDropdownSection>
             </NeuroglancerDropdown>
             <NeuroglancerDropdown title="Actions" variant="outlined">


### PR DESCRIPTION
Issue [#CC-449](https://metacell.atlassian.net/browse/CC-449)
Problem: Apply styling from figma to the tomogram select dropdown
Solution: 
1. Pass title and subtitle as props, so they can be easily customizable
2. Fix style for disabled state

Result: 
<img width="695" height="479" alt="image" src="https://github.com/user-attachments/assets/01f5e9bc-1535-47bd-8f7d-fe37072d63ba" />
